### PR TITLE
Minor 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "password-generator",
-	"version": "2.0.3",
+	"version": "2.1.0",
 	"private": true,
 	"dependencies": {
 		"@craco/craco": "^6.4.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@testing-library/react": "^13.4.0",
 		"@testing-library/user-event": "^14.4.3",
 		"@types/craco__craco": "^6.4.0",
-		"@types/jest": "^29.2.0",
+		"@types/jest": "^29.2.3",
 		"@types/node": "^18.11.9",
 		"@types/react": "^18.0.24",
 		"@types/react-dom": "^18.0.9",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@types/jest": "^29.2.0",
 		"@types/node": "^18.11.9",
 		"@types/react": "^18.0.24",
-		"@types/react-dom": "^18.0.0",
+		"@types/react-dom": "^18.0.9",
 		"@types/webextension-polyfill": "^0.9.1",
 		"react-scripts": "5.0.1"
 	},

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@testing-library/user-event": "^14.4.3",
 		"@types/craco__craco": "^6.4.0",
 		"@types/jest": "^29.2.0",
-		"@types/node": "^18.11.8",
+		"@types/node": "^18.11.9",
 		"@types/react": "^18.0.24",
 		"@types/react-dom": "^18.0.0",
 		"@types/webextension-polyfill": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@craco/craco": "^6.4.5",
-		"@fluentui/react-components": "^9.6.1",
+		"@fluentui/react-components": "^9.7.1",
 		"@fluentui/react-icons": "^2.0.186",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"@fluentui/react-icons": "^2.0.186",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"sass": "^1.55.0",
+		"sass": "^1.56.1",
 		"typescript": "^4.8.4",
 		"webextension-polyfill": "^0.10.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -8513,10 +8513,10 @@ sass-loader@^12.3.0:
     klona "^2.0.4"
     neo-async "^2.6.2"
 
-sass@^1.55.0:
-  version "1.55.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.55.0.tgz#0c4d3c293cfe8f8a2e8d3b666e1cf1bff8065d1c"
-  integrity sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==
+sass@^1.56.1:
+  version "1.56.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.56.1.tgz#94d3910cd468fd075fa87f5bb17437a0b617d8a7"
+  integrity sha512-VpEyKpyBPCxE7qGDtOcdJ6fFbcpOM+Emu7uZLxVrkX8KVU/Dp5UF7WLvzqRuUhB6mqqQt1xffLoG+AndxTZrCQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,241 +1243,235 @@
   dependencies:
     "@floating-ui/core" "^1.0.1"
 
-"@fluentui/keyboard-keys@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/keyboard-keys/-/keyboard-keys-9.0.0.tgz#89efe56e00bb451e5f6daa67ffbf2f4f19a71457"
-  integrity sha512-8oxbUYfsUG9Qwy0akfXkECyMj6wJtrRB6ZOO1ngYDBvSq6yY6Ifg+ezFiRC8IxRaHf/yqwXjGOHUZy1ZOrd+Ww==
+"@fluentui/keyboard-keys@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/keyboard-keys/-/keyboard-keys-9.0.1.tgz#56e5557c996f7b82d52e8182bc8dc1aa4554d581"
+  integrity sha512-I22XoRFvVHSfJ4xiaYRQensHODhPel9KDn4t0FxHPvBH1u04vNYOXIimqSHgIVMRUdOb6221IOcv4XsKBBiG6w==
   dependencies:
     tslib "^2.1.0"
 
-"@fluentui/priority-overflow@^9.0.0-beta.3":
-  version "9.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/priority-overflow/-/priority-overflow-9.0.0-beta.3.tgz#c1c12bb29226650d211ec3fbd2326c1bcc2dee8f"
-  integrity sha512-CoDe3S7bdX2wu062TSRVtAmjPvIoRjx4IiK2Fn1iZDwFayiMomjpp+5ESLea4xzMmA2eWMJ9U6spPUcIlMncnQ==
+"@fluentui/priority-overflow@^9.0.0-rc.1":
+  version "9.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/priority-overflow/-/priority-overflow-9.0.0-rc.1.tgz#63456e5c02702080546849ed406bae6f2a8af479"
+  integrity sha512-qZ/W9vQgNSe6TYV02iobDjCoQWQsfLcnLnjK9iN3UNGZZiLsEDCtD4yIjREoXT1oPt0c62gHOjyFe0G0nYZurw==
   dependencies:
     tslib "^2.1.0"
 
-"@fluentui/react-accordion@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.0.9.tgz#0f420e4d684bca23b8befc7e681b445ef1d4d0d4"
-  integrity sha512-DG8OQChYt8x5Cly6WgbZEO74AIaEfp/vrfjPuqv6HqAoO3c2dmNKE2kjhJkqAi3C71UKdQ/ZaYPELh+RAH3SfA==
+"@fluentui/react-accordion@^9.0.12":
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-accordion/-/react-accordion-9.0.12.tgz#090ace2754509fe212ff70a864219f2df70e1593"
+  integrity sha512-lXo96eq+1ZHcAgqSRkEvxi4VlTrOLXx0F6xnT6gqZ9dProVMlosyHbarj6ADGZBXV5aF4HbjdIkRLFa2zwkrFA==
   dependencies:
-    "@fluentui/react-aria" "^9.2.3"
-    "@fluentui/react-context-selector" "^9.0.5"
+    "@fluentui/react-aria" "^9.3.2"
+    "@fluentui/react-context-selector" "^9.1.2"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-alert@9.0.0-beta.15":
-  version "9.0.0-beta.15"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-alert/-/react-alert-9.0.0-beta.15.tgz#29622dc5a6163b73b517f3b7f9230a6c67c31912"
-  integrity sha512-E1QVhlaqoHACtHpE94qj50GTg9JM43fqNK1efpmI2rwdKQ7DWwR6c0zg9y9pW4pbYwCMjN/rfsaAiDwdT7HeBg==
+"@fluentui/react-alert@9.0.0-beta.18":
+  version "9.0.0-beta.18"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-alert/-/react-alert-9.0.0-beta.18.tgz#7f6a52aa11b2fcae72cfae0cc72bd7b881263634"
+  integrity sha512-xCAGaDuZ/JnnAu2n5DGfpvynAcwMVWHmDzLUxXzbzMSVXb6aqs2OepWG5DE+ZcY8NYyij0xTsRSu08mHGxOmjw==
   dependencies:
-    "@fluentui/react-avatar" "^9.2.4"
-    "@fluentui/react-button" "^9.1.6"
+    "@fluentui/react-avatar" "^9.2.7"
+    "@fluentui/react-button" "^9.1.9"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-aria@^9.2.3":
-  version "9.2.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.2.3.tgz#ecced8405d971787be0ee9308ec788e8146b9e1c"
-  integrity sha512-LuEym1AeX7jyjk0jw7uexppXzw9sxJ+H2OT7psVMElPukFCJifCvCT378Q4E9ktCULjuaBqs0+6FCswwzUkLFg==
+"@fluentui/react-aria@^9.3.2":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-aria/-/react-aria-9.3.2.tgz#1054b5b7d50f898fd417abe46853be1831435dbf"
+  integrity sha512-uP9tSUpggVTdtnsEx5WBTuTTXoknJrAb/1Jm+inXa9BRPQDG/9HjMM9Q2jPKukFOAibwlmXYcecoIVyx/FO7ow==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-utilities" "^9.1.2"
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-utilities" "^9.2.2"
     tslib "^2.1.0"
 
-"@fluentui/react-avatar@^9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.2.4.tgz#a04d3ab71cfeaaa0f7335f86ebdbdfd279cb5c6d"
-  integrity sha512-mPCH5OXcAMkBk7q3jJIYfG9AWSLo/6X4kxJrBwQSluSKAACFI7ohwDS8T3WAN9F0R2Lk39mJQbjOu9q1qPdY6w==
+"@fluentui/react-avatar@^9.2.7":
+  version "9.2.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-avatar/-/react-avatar-9.2.7.tgz#dc59e7d6bdca209329834e7e905d97e0c1c4537f"
+  integrity sha512-E4+58bcUn0osX26CCjm1jqa6PRcSZLsOhtJLXKDqJDDopqjUhe6fuxuHQ7sITwr+qB/umKIG5lBUTd5jilUrAw==
   dependencies:
-    "@fluentui/react-badge" "^9.0.10"
-    "@fluentui/react-context-selector" "^9.0.5"
+    "@fluentui/react-badge" "^9.0.13"
+    "@fluentui/react-context-selector" "^9.1.2"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-popover" "^9.2.1"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-tooltip" "^9.0.9"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-popover" "^9.3.2"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-tooltip" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-badge@^9.0.10":
-  version "9.0.10"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.0.10.tgz#a1b712128ee94ab005f81862c06a09739c2b1746"
-  integrity sha512-+HEz4l3ZAxyDAcucHlF2sHa+xZY3F/ostub0kQDDQxBDG2zgTR+RlM+mqyOcvq5hhUTjpQsRAtODVdZClRUztQ==
-  dependencies:
-    "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-button@^9.1.6":
-  version "9.1.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.1.6.tgz#65e009e2bc5ec1faf85e43b8c0ca4fceb91f8e7a"
-  integrity sha512-Fa93JhLEmqu+B4dNj26q9yVLbWyDZx1EuPQomvSRMxtbpInD7Xx29qH3g4QYPafrgzxI7NNSbnT8MFl1YME/Tg==
-  dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-aria" "^9.2.3"
-    "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-card@9.0.0-beta.30":
-  version "9.0.0-beta.30"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.0-beta.30.tgz#19f5e924fd34076941a8280aaf742cab6a2d9fe8"
-  integrity sha512-9pSDq4Acac9p8pEfh/mQqncBOvxUuhjepVa4sbZGqIyYeSaVvBkbPM2ZUakBPUwGudbma7hDiD4BnhkLr3ytYg==
-  dependencies:
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-checkbox@^9.0.10":
-  version "9.0.10"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-checkbox/-/react-checkbox-9.0.10.tgz#be7a9c6a6b86377d3e01a6fb663df8da8edf4f05"
-  integrity sha512-yYGfA+LB7l/myxH+aAjdjshtR60EYC0Tl+IznPAJIdeQlvnJAMzu6p3/w11aKCU/v6M9OdaR7zgZRDYWoQOktg==
+"@fluentui/react-badge@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-badge/-/react-badge-9.0.13.tgz#dbb2b1e62e9ef7626d8a898202620c8e97c3bb9f"
+  integrity sha512-/6cDpf29z4SFQ+WCqQAwYxj3fY0z+PDVopldK5+Kdggi6NphfrkLhB9CUUdsDCqEk5oC2skRnsNPRdC+kNAsZQ==
   dependencies:
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-label" "^9.0.8"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-combobox@^9.0.0-beta.13":
-  version "9.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-combobox/-/react-combobox-9.0.0-beta.13.tgz#16655980acd700c978a1f01c6d66aa4f8e304d4c"
-  integrity sha512-3e8UmwnVUHmKQcBDIr7pYrDHGC1VO6HXGidf4GwQQUcIhV0HWV9cGrelLKruvCVbWX655yAlaEfL4oCirlrJBA==
+"@fluentui/react-button@^9.1.9":
+  version "9.1.9"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-button/-/react-button-9.1.9.tgz#6987eb1a5611d96f8389b283d407f1c1f3e4632d"
+  integrity sha512-M80Pb/vS/CL150ZGSH46mAvBUASrzSLxaeyBozAyOVJ2p9jFsRxCe/BVn01IVnzgOmem3O3HBcJrqsMRMVErZg==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-context-selector" "^9.0.5"
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-aria" "^9.3.2"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-portal" "^9.0.8"
-    "@fluentui/react-positioning" "^9.2.2"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-components@^9.6.1":
-  version "9.6.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.6.1.tgz#04ea26dc0e3c38b4df3793aa28b8eeb11e9f58b2"
-  integrity sha512-2/K/MSAKKZQ9RFk7U1idjSRnaOYhz8qKVpWi4IrBDA0UAldTTdseIXHayIske6HFMicG5SYixsTT57A8+TE2xQ==
+"@fluentui/react-card@9.0.0-beta.33":
+  version "9.0.0-beta.33"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-card/-/react-card-9.0.0-beta.33.tgz#e1efe00e43f9cb71d43809e61db8508872e05fab"
+  integrity sha512-sd+/DEjzc0fSDkP2MfO3mUutZWHfu6H083EJ+e0hgrJVQ7REfDwNDjCA+mAzcB/cfxSc5FC8RvQeZB6mL2/Tow==
   dependencies:
-    "@fluentui/react-accordion" "^9.0.9"
-    "@fluentui/react-alert" "9.0.0-beta.15"
-    "@fluentui/react-avatar" "^9.2.4"
-    "@fluentui/react-badge" "^9.0.10"
-    "@fluentui/react-button" "^9.1.6"
-    "@fluentui/react-card" "9.0.0-beta.30"
-    "@fluentui/react-checkbox" "^9.0.10"
-    "@fluentui/react-combobox" "^9.0.0-beta.13"
-    "@fluentui/react-dialog" "^9.0.3"
-    "@fluentui/react-divider" "^9.1.2"
-    "@fluentui/react-field" "9.0.0-alpha.6"
-    "@fluentui/react-image" "^9.0.9"
-    "@fluentui/react-input" "^9.2.3"
-    "@fluentui/react-label" "^9.0.8"
-    "@fluentui/react-link" "^9.0.9"
-    "@fluentui/react-menu" "^9.3.1"
-    "@fluentui/react-overflow" "9.0.0-beta.12"
-    "@fluentui/react-persona" "9.1.0-beta.1"
-    "@fluentui/react-popover" "^9.2.1"
-    "@fluentui/react-portal" "^9.0.8"
-    "@fluentui/react-positioning" "^9.2.2"
-    "@fluentui/react-progress" "9.0.0-alpha.3"
-    "@fluentui/react-provider" "^9.1.5"
-    "@fluentui/react-radio" "^9.0.9"
-    "@fluentui/react-select" "9.0.0-beta.12"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-slider" "^9.0.8"
-    "@fluentui/react-spinbutton" "^9.0.6"
-    "@fluentui/react-spinner" "^9.0.8"
-    "@fluentui/react-switch" "^9.0.9"
-    "@fluentui/react-table" "9.0.0-alpha.8"
-    "@fluentui/react-tabs" "^9.0.9"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-text" "^9.1.4"
-    "@fluentui/react-textarea" "^9.1.3"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-toolbar" "9.0.0-beta.11"
-    "@fluentui/react-tooltip" "^9.0.9"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-context-selector@^9.0.5":
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.0.5.tgz#dc65469c827b156060625e59b2a815fbfbb99e41"
-  integrity sha512-4H2tG7y6IGfPwPCpHnjh6rcQXxjhjKkT+3qiRRmTXUkQdaWCEDwrQ0UHkHjGAWdWA7hi6/eALPxe+AF3ZIpl5Q==
+"@fluentui/react-checkbox@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-checkbox/-/react-checkbox-9.0.13.tgz#13cb1b3eac73901bfcd445356970c4c2bce44fcf"
+  integrity sha512-HlzL+GkdTMbPKdSYAkwxR4H9KfmIrbVFRTILsg81gMZmkuhPvUVblYxoRN20UZHjKn4TAjb41KZ6fhtaG/WnZA==
   dependencies:
-    "@fluentui/react-utilities" "^9.1.2"
-    tslib "^2.1.0"
-
-"@fluentui/react-dialog@^9.0.3":
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-dialog/-/react-dialog-9.0.3.tgz#d175ad11abd88afe36b7714455b8e78c164801ac"
-  integrity sha512-YXi4QIkyFfSlQO36qQp9FX7DItcTPAgD6bb9DwvtsVKRMMkm8b3e8wa647skvOogmHDgVyex9Os5rDdDZc1+1A==
-  dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-aria" "^9.2.3"
-    "@fluentui/react-context-selector" "^9.0.5"
+    "@fluentui/react-field" "9.0.0-alpha.9"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-portal" "^9.0.8"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-label" "^9.0.11"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-divider@^9.1.2":
+"@fluentui/react-combobox@^9.0.0-beta.16":
+  version "9.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-combobox/-/react-combobox-9.0.0-beta.16.tgz#da4dd3ec15ea432ef522275e94f73fba90bba0c0"
+  integrity sha512-j/lAwNvGAS29Vstvx2Wf1Zkc4f+vajEN4Mf1Wzx4cixVqekQodpMlnm56FqZLWKMUxEA8uXauEfNN+eRVRUuSA==
+  dependencies:
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-icons" "^2.0.175"
+    "@fluentui/react-portal" "^9.0.11"
+    "@fluentui/react-positioning" "^9.3.2"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-components@^9.7.1":
+  version "9.7.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-components/-/react-components-9.7.1.tgz#00a9cdd48ec0d63b9fa60e0effd41233bbc80da8"
+  integrity sha512-VChSbliVKWdP5fFN0urUOo1iaLQNk5w3FemG9B47mDupK+F/jc2V6Kw+838ti93/sr/o9Aw3bK+MInlr41U0Ag==
+  dependencies:
+    "@fluentui/react-accordion" "^9.0.12"
+    "@fluentui/react-alert" "9.0.0-beta.18"
+    "@fluentui/react-avatar" "^9.2.7"
+    "@fluentui/react-badge" "^9.0.13"
+    "@fluentui/react-button" "^9.1.9"
+    "@fluentui/react-card" "9.0.0-beta.33"
+    "@fluentui/react-checkbox" "^9.0.13"
+    "@fluentui/react-combobox" "^9.0.0-beta.16"
+    "@fluentui/react-dialog" "^9.1.2"
+    "@fluentui/react-divider" "^9.1.5"
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-image" "^9.0.12"
+    "@fluentui/react-infobutton" "9.0.0-beta.1"
+    "@fluentui/react-input" "^9.2.6"
+    "@fluentui/react-label" "^9.0.11"
+    "@fluentui/react-link" "^9.0.12"
+    "@fluentui/react-menu" "^9.5.0"
+    "@fluentui/react-overflow" "9.0.0-rc.1"
+    "@fluentui/react-persona" "9.1.0-beta.4"
+    "@fluentui/react-popover" "^9.3.2"
+    "@fluentui/react-portal" "^9.0.11"
+    "@fluentui/react-positioning" "^9.3.2"
+    "@fluentui/react-progress" "9.0.0-alpha.6"
+    "@fluentui/react-provider" "^9.1.8"
+    "@fluentui/react-radio" "^9.0.12"
+    "@fluentui/react-select" "9.0.0-beta.15"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-slider" "^9.0.11"
+    "@fluentui/react-spinbutton" "^9.0.9"
+    "@fluentui/react-spinner" "^9.0.11"
+    "@fluentui/react-switch" "^9.0.12"
+    "@fluentui/react-table" "9.0.0-alpha.12"
+    "@fluentui/react-tabs" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-text" "^9.1.7"
+    "@fluentui/react-textarea" "^9.1.6"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-toolbar" "9.0.0-beta.14"
+    "@fluentui/react-tooltip" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-context-selector@^9.1.2":
   version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.1.2.tgz#cd789f3273d449f0e2d0074739bd4745830b569a"
-  integrity sha512-nsK/TXH8FX/dlcAoKlQoPL8Z4xwQ3UCcJf/fYozAnGWJEMlx7D14lmewYPotVAheVs2AhIw6UIJ7MhtPDo7bvQ==
+  resolved "https://registry.yarnpkg.com/@fluentui/react-context-selector/-/react-context-selector-9.1.2.tgz#760a9b90e8fac48ef4fa125f035247a64b982c39"
+  integrity sha512-NncwaLjcaVe/56a1fQr6F0lxKth6XAOQQHNFRnr4NMEmQdfBG4SDtbaCLEAzOjiSBEKcC0jNKoiC5IUQioNYBw==
   dependencies:
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-utilities" "^9.2.2"
     tslib "^2.1.0"
 
-"@fluentui/react-field@9.0.0-alpha.6":
-  version "9.0.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-field/-/react-field-9.0.0-alpha.6.tgz#23a0bad1dbea31e63d0b4756bc035c1e64e473f5"
-  integrity sha512-dNfngWC1hVodokwDvb+jFzYouu1wpi+2bRFBwMeYrM7kPN7VwoyW3VW2J3w0HSi2jnr+9BjtqjuEUok53sZDxw==
+"@fluentui/react-dialog@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-dialog/-/react-dialog-9.1.2.tgz#937b918e53ed0ee6bb40d81353e1fb8bb6d63003"
+  integrity sha512-4ZSWAFya8XJZUD6VU23cfyf7grMNeXdoyvOManAjpq6KplEGUz7MT78uGjaJyY19Jx4Krn35Uz9CE4csdTaiuQ==
   dependencies:
-    "@fluentui/react-checkbox" "^9.0.10"
-    "@fluentui/react-combobox" "^9.0.0-beta.13"
-    "@fluentui/react-context-selector" "^9.0.5"
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-aria" "^9.3.2"
+    "@fluentui/react-context-selector" "^9.1.2"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-input" "^9.2.3"
-    "@fluentui/react-label" "^9.0.8"
-    "@fluentui/react-progress" "9.0.0-alpha.3"
-    "@fluentui/react-radio" "^9.0.9"
-    "@fluentui/react-select" "9.0.0-beta.12"
-    "@fluentui/react-slider" "^9.0.8"
-    "@fluentui/react-spinbutton" "^9.0.6"
-    "@fluentui/react-switch" "^9.0.9"
-    "@fluentui/react-textarea" "^9.1.3"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-portal" "^9.0.11"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-divider@^9.1.5":
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-divider/-/react-divider-9.1.5.tgz#1fa24c1e1acfe3a0a6a44f084da9c6c1eb2a0f86"
+  integrity sha512-FhuxZJSEDOG6Kx1npdcQNvu+BmkQUVGM72YSCTXOZQAIaZzJm8hrPyUP1uv0nZxwIuH8s20WxmoG3dRzGmwKKA==
+  dependencies:
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-field@9.0.0-alpha.9":
+  version "9.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-field/-/react-field-9.0.0-alpha.9.tgz#cb13d148b4fd024e3279b43223e56791af84a04e"
+  integrity sha512-sv6HuBzxYbYtCJIfKi5XQB9jsCemQ6/ppR/apzBRFHe9rPzjXGYRShMmDBeKh57E/N18tldSMtDXJ0GHSPoqZA==
+  dependencies:
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-icons" "^2.0.175"
+    "@fluentui/react-label" "^9.0.11"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
 "@fluentui/react-icons@^2.0.175", "@fluentui/react-icons@^2.0.186":
@@ -1488,350 +1482,361 @@
     "@griffel/react" "^1.0.0"
     tslib "^2.1.0"
 
-"@fluentui/react-image@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.0.9.tgz#14d35affb13d3b39012a5a23c45bccc6e89c0a7e"
-  integrity sha512-qvAgtQ33h5aN/VDWa8xVziX53G/c25CjNIu10rBzBAr83/51jluMtnniI4BeTJPfaWDwaEM8jL1IGTO3ui6pMg==
+"@fluentui/react-image@^9.0.12":
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-image/-/react-image-9.0.12.tgz#8cc7132177594df085edbbb67ce2f41622770f6c"
+  integrity sha512-xKL0DJTle+svie+bi2fZgiutkYA4f9GcA7Gu740gzGgGxtqZ24d9mMevYVLyAd7wZzNapDJ/gc6qNfxkcgHe5g==
   dependencies:
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-input@^9.2.3":
-  version "9.2.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-input/-/react-input-9.2.3.tgz#71f72c4f4e14acc32d7f328c823d524b83a0a0a5"
-  integrity sha512-mLeY5iGk62I6QchVH27SYKvhncsCjRy2YbNm4QWfeRrOJrLDA//wo3/DckbWk+6WcvOg+9ymDIes7cpF5hCuRg==
+"@fluentui/react-infobutton@9.0.0-beta.1":
+  version "9.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.1.tgz#552e50e8e5b767c9d41d44a9c868c7992034d0fb"
+  integrity sha512-XyP8rhwcypUCUqQrSvgYdO+Rc4M6LZRHVcPgxCoLcAcvRgdg7/Q3FyE5V3ULtZkJofleLgd/6o6qaBW2iLIgQQ==
   dependencies:
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-label@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.0.8.tgz#bb87277ee6496606e3e41a1eb530d45a8bc00749"
-  integrity sha512-19t/gGtgtWs1MqARDbr/PrTHtBxbtDihjGQALMuCHlbzTHwUBRfnrI1misXVbHktU2Nc6aIB4IZj/1/mh/1MFQ==
-  dependencies:
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-link@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.0.9.tgz#35b857e5a11fed6461c9aa17855e36273782423a"
-  integrity sha512-d/FWsxu6fg5hUlOvP/DulKAKewdMiqok3THCcrPhx8nvt/fYnDanlGYq5Zl/95ZubTEOYL2luz6Mt5VSk2JPhA==
-  dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-menu@^9.3.1":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.3.1.tgz#d72596be797ce405b1869440c76afcf31b41132b"
-  integrity sha512-MAEQ5NbiW/O2a5oLOsORJVkqYogj5gkegF0IeqfbB9CQVHE64J6yz+KaMNoihhzmDs1J+oFMG0653d+um2ifIw==
-  dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-aria" "^9.2.3"
-    "@fluentui/react-context-selector" "^9.0.5"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-portal" "^9.0.8"
-    "@fluentui/react-positioning" "^9.2.2"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-popover" "^9.3.2"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-overflow@9.0.0-beta.12":
-  version "9.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-overflow/-/react-overflow-9.0.0-beta.12.tgz#7d1ca664084d152444743c196eae0b0751c490af"
-  integrity sha512-bF3Mn6t41dQ7EeDMZN4cPfJrugT1H6cTqY+XHgkJC57zSx3KihmFR3MvG7S6yI6+PO8ejLWIT1wTtQemteLdYw==
+"@fluentui/react-input@^9.2.6":
+  version "9.2.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-input/-/react-input-9.2.6.tgz#45e68e760b9055b5c13c24654df07bec4f69e70b"
+  integrity sha512-oY+mo8LRqQIp0oU1YPpyqQkRb0ZCFD70vEa0Ns148gjnv3E1RV+9SkLeRDRjx/wKY4i7fFCFclZAHZM9T2srAg==
   dependencies:
-    "@fluentui/priority-overflow" "^9.0.0-beta.3"
-    "@fluentui/react-context-selector" "^9.0.5"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-persona@9.1.0-beta.1":
-  version "9.1.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-persona/-/react-persona-9.1.0-beta.1.tgz#ab361be04a0b379221d1d50be3af5be929d76052"
-  integrity sha512-BcpbuNusfPbcNEFpNLwOVhhLla3mYeX2C1b5NU+j6vOtf8odalpHUF9wiQb8a+z0U7jQQ+HybYdDWH3ZVxVwfQ==
+"@fluentui/react-label@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-label/-/react-label-9.0.11.tgz#7790c2b54dbba5a7a6c054e68ab743c547abc341"
+  integrity sha512-cZZr/yo6uT+U4tuFbGM5ujAot6YSWEDR70S8XJRcnyP794PQzWNDdTnlh/4UX2mgAmkv8Si4xEgWuyM+98KZ7w==
   dependencies:
-    "@fluentui/react-avatar" "^9.2.4"
-    "@fluentui/react-badge" "^9.0.10"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-popover@^9.2.1":
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.2.1.tgz#58adfe9f42387e08565bb7ff02bc17d4658b4c68"
-  integrity sha512-o45o9i5JKJcvQhI6mgtq0laVJ4/7HOpMwWcfFAC4Hvc0NC7psRNuUfb0o5pHbMjiQIY/xCXLRZRPP8eoxhZ+dg==
+"@fluentui/react-link@^9.0.12":
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-link/-/react-link-9.0.12.tgz#3efea006c7abaf1a4cae419ec31e8f41746d82fa"
+  integrity sha512-QMefPhBecyk4Nn+sdMf0WLYTc/7J3ViAXGCGEGvbB+eyAnNpXdU/aduqJOHR6MSX/TFH2k95jAaD8qqqmODlUQ==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-aria" "^9.2.3"
-    "@fluentui/react-context-selector" "^9.0.5"
-    "@fluentui/react-portal" "^9.0.8"
-    "@fluentui/react-positioning" "^9.2.2"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-portal@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.0.8.tgz#015cff1e51465d3e8af0f1fe939a088679147fe1"
-  integrity sha512-rONrOMkGwwF/KmB1VZzt2JYmrmVVCGxUm+8a4SPOvEhtFqa3LYx962v33TysDHg6aq4Wgve9D837O3VkSmWehA==
+"@fluentui/react-menu@^9.5.0":
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-menu/-/react-menu-9.5.0.tgz#03d6f9dbfc975d03fbd85a69186512ae538bb765"
+  integrity sha512-MM28e6DiqNIijqGiLx395EA9HacnPi79U3u7QqgBy9U5TTiFZlo/Wr+jWd6r7Ec7IXgHnrNGYRBXuZkxDbM0dw==
   dependencies:
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-aria" "^9.3.2"
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-icons" "^2.0.175"
+    "@fluentui/react-portal" "^9.0.11"
+    "@fluentui/react-positioning" "^9.3.2"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-positioning@^9.2.2":
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.2.2.tgz#dfce96fe705c3dbd8379f0d1ae39de92dd9bfc25"
-  integrity sha512-mKO8FD1hjINCAWpYwTOlgGP9y8RcKXQhUrOu19GmkIwox0K6fF2dC9/yzI/EqYSBkwneQEastAUDxJOq5TGfDw==
+"@fluentui/react-overflow@9.0.0-rc.1":
+  version "9.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-overflow/-/react-overflow-9.0.0-rc.1.tgz#0fdf2397b5a33237bb9a622e4b753329d08593a2"
+  integrity sha512-ySV1Lza/5taHg9q9PLE6E2LxedLk7tW6YnbuWsyWz6fPG759vJC6NKA4Ewsl6bppzb4FE+28W+MsypcUhxQn8w==
+  dependencies:
+    "@fluentui/priority-overflow" "^9.0.0-rc.1"
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-persona@9.1.0-beta.4":
+  version "9.1.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-persona/-/react-persona-9.1.0-beta.4.tgz#a81004956b00e527c945b963ff81046002119771"
+  integrity sha512-+ZymZfLEldX6PdxHfbjnkIruZCh2PM8++rJWTuHH+mcWxr78ySVpqp1oz0XtfOdhs7lvf4m25V5PXNrqFiZ90A==
+  dependencies:
+    "@fluentui/react-avatar" "^9.2.7"
+    "@fluentui/react-badge" "^9.0.13"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-popover@^9.3.2":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-popover/-/react-popover-9.3.2.tgz#c51f58fb3c35fc6aab67251b22fd63b5d7e14acf"
+  integrity sha512-fdScHvptUEY1jbTqx6NuT5jobP/PZuPjw5Wt2yNNi2RHh9cqC9NGdJg4PTJJEZGC2Fkep7Ur+4N/i7fl5Abypw==
+  dependencies:
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-aria" "^9.3.2"
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-portal" "^9.0.11"
+    "@fluentui/react-positioning" "^9.3.2"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-portal@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-portal/-/react-portal-9.0.11.tgz#a4177c34c3e08fa99de60365f69a82771e7f6485"
+  integrity sha512-Li3EbVCJz3FrQM+A+ZY45mf1AE47XXIGultBlKOcFOy/ZMh6GyY6AGqhQL6NTLB/a3sDsYElMZe+Nc2sOSABKA==
+  dependencies:
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-positioning@^9.3.2":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-positioning/-/react-positioning-9.3.2.tgz#2f82919a6b39ff0da3049579b9d3fc34691a4ac0"
+  integrity sha512-9R/in6LPi2y0bSlYVAhsM+gBLTO+4b5XpU6ZMMJlbcKaWMG849PJ9dOSy6dWmmf7KIkmwouUvsNpjQofF7/7Nw==
   dependencies:
     "@floating-ui/dom" "^1.0.0"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-progress@9.0.0-alpha.3":
-  version "9.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-progress/-/react-progress-9.0.0-alpha.3.tgz#bc4da17514902fe9902134d0ed20211fb4b0953f"
-  integrity sha512-Z7SYafdB74KJdF/qQbknthfE24whIMO0HYRxlLPoqJKR2wRkGrbxCF5U4mQruG1fhnk+6diEZV0CnsfHXIrn/A==
+"@fluentui/react-progress@9.0.0-alpha.6":
+  version "9.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-progress/-/react-progress-9.0.0-alpha.6.tgz#51020f3d45ff93ab8ed9caa32274b2f0c96cc335"
+  integrity sha512-QJHZSjjXhCP8xUXKfSaqLBvtLHIGcFMswra2Q6x5NNS7eJnmomeak9eFkTWJybO7ngPyigS+ULarXYVxERiy9w==
   dependencies:
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-provider@^9.1.5":
-  version "9.1.5"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.1.5.tgz#3c4c5e87637676263948ab6182fef21b54acc34d"
-  integrity sha512-yoaRsNvD0Ni218+8pWcLVYI0MsT4hnsTBFycg7n/tETYiTvbvCTQ8WybO2yHw/l2Xa8Vknm+E05W1CoNlIruFA==
+"@fluentui/react-provider@^9.1.8":
+  version "9.1.8"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-provider/-/react-provider-9.1.8.tgz#69f6dcc489d0addb52f64b57aaeaa4f21012c684"
+  integrity sha512-tT0HwrZr76s1Bn+dDWUA3D4CvMa6nTHpY4UTUgGChMLVEwaNchxaQ70MH3xBmDbvxsMef8Fi3upRh1L52I2pVg==
   dependencies:
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/core" "^1.8.0"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/core" "^1.8.1"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-radio@^9.0.9":
+"@fluentui/react-radio@^9.0.12":
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-radio/-/react-radio-9.0.12.tgz#a5bb280e89851593fbad197d28ebff39a0645c6d"
+  integrity sha512-G561z6aADFdm7K68zLOt4I6IOFxyvyAGBSnmSTsl+t5Znt27IfL0rSrQx+O0ziJ3PT2q2EQmASX4057ycP9XHA==
+  dependencies:
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-icons" "^2.0.175"
+    "@fluentui/react-label" "^9.0.11"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-select@9.0.0-beta.15":
+  version "9.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-select/-/react-select-9.0.0-beta.15.tgz#0f1112a434660705952a3f3bab67fb2c608f9ac1"
+  integrity sha512-eIahqyFiS0D+2vlTRNAKWNz55ZxW+yokNJ+F6qqxXOZUhRcsVUm4ARsZ3XhHzR5eW+yl7XqaC1mkyJXLqnrMGw==
+  dependencies:
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-icons" "^2.0.175"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-shared-contexts@^9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.1.1.tgz#bd7c09cd970645342f65e3fc8b05d43847295ea5"
+  integrity sha512-AX/sV2KAOSVOzIwXh+hkwCl12Fkj3eg+kKo22eHjcovGkqrAvA9TegN/37NAa1ttAVRWpA32D1MwGUNkNvnpZw==
+  dependencies:
+    "@fluentui/react-theme" "^9.1.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-slider@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-slider/-/react-slider-9.0.11.tgz#aaa7e96fb015992a12e026eab5ebd946c89e2108"
+  integrity sha512-D+5sVew+Kaj34/ZgR01nzWwIcGokQbys2USJaNrcKTbgLaqAAE+pLynozpdla3LrACEWNI6YusGcRefaAyCcaw==
+  dependencies:
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-spinbutton@^9.0.9":
   version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-radio/-/react-radio-9.0.9.tgz#d11b078dd735e26a75ade0586b6085d2175761df"
-  integrity sha512-zPeNOYvodOt24wOwjKxgOHG/7tjAGHJq8CiJCZxnWVnRXUgsi4Tm222DT1aCDc/PfZIwdSN4L5xR0XmfNeBN8Q==
+  resolved "https://registry.yarnpkg.com/@fluentui/react-spinbutton/-/react-spinbutton-9.0.9.tgz#d0f023e87f61ad5b3d2bb88556c57e05ebaf1970"
+  integrity sha512-hd4Bk+Ai6MP+WM5ewasXncIhlTobueyrQcPRnKpp6JXdM5Ej4s0Pgp5F9VDXBr7Fyw/UMs/iEUjvV3y30cI86Q==
   dependencies:
-    "@fluentui/react-context-selector" "^9.0.5"
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-field" "9.0.0-alpha.9"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-label" "^9.0.8"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-input" "^9.2.6"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-select@9.0.0-beta.12":
-  version "9.0.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-select/-/react-select-9.0.0-beta.12.tgz#7edc3e6c04bee8c45409940f905ee085d1a7da4d"
-  integrity sha512-oesJ32j7o34YkqqEgMVg3oppJB5XesQFaiZj+jWGwn0HKRNsos7R3F/dh+HKhJxejuIZZPFzAhJ+uzphshMvLQ==
+"@fluentui/react-spinner@^9.0.11":
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-spinner/-/react-spinner-9.0.11.tgz#59321ad01ca8215acc5d91760b83de344dff2e3f"
+  integrity sha512-KeOpq+KhNSnCdEP8nzU0ZE2RzEELz4rTTv1jVSFHNj97Mm2HG/3p3IGr9LSdxYpikwjY1k09TsOwv3cmsCI32A==
   dependencies:
+    "@fluentui/react-label" "^9.0.11"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-switch@^9.0.12":
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-switch/-/react-switch-9.0.12.tgz#26ffae91b48a57a727c748fe62e76c9b808fd089"
+  integrity sha512-l5kkFh/NrxPH8ERKAMg+NGtcp4Y3I7KQhL8uE+A/y0pId7s80MtCCns5Vg9iS8hgWSYjQAmkObZQNljWiNL64w==
+  dependencies:
+    "@fluentui/react-field" "9.0.0-alpha.9"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-label" "^9.0.11"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-shared-contexts@^9.0.2":
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-shared-contexts/-/react-shared-contexts-9.0.2.tgz#89496f7a7daf4e0b6417e5075fb66e128e85741e"
-  integrity sha512-KSrxc4WcgL1/w8mahLRTJvzG0CCC3OP5wXSLyppaPfFQU9EaEdicDJHtq0SzvqKfim/sKdfTmFa1Z5kVsagFAQ==
+"@fluentui/react-table@9.0.0-alpha.12":
+  version "9.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-table/-/react-table-9.0.0-alpha.12.tgz#559a841299ecba537a89ff35d48d8132d07b168e"
+  integrity sha512-7mwMdLsL75T46dLYsbK+zi9djhd57uIbTBFsqqRPircrj8vS2VGi3jZTijv6a6BkyxawmWcxKcW1zPEIHamo/w==
   dependencies:
-    "@fluentui/react-theme" "^9.1.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-slider@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-slider/-/react-slider-9.0.8.tgz#583f7d0fadec7ff2102794852d57614eec6c659e"
-  integrity sha512-B421LOZLgAOcTwe5jJHEVKVqjJqF0Yfm5zC9LcMAWm3dPlhDqWL9dqaFzrkTc91I5kCQuyLVfH4AZ3E3FZA/PQ==
-  dependencies:
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-spinbutton@^9.0.6":
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-spinbutton/-/react-spinbutton-9.0.6.tgz#fb820b4183aed5c50c5fb22f8ce3d3217b03306c"
-  integrity sha512-rDFBAqyWZis45p2llHrJddLRVnwJvskHynPAhnD5B8i85CFZw/S/14DRKI4kGB9imUQduMt7VbeZbjtqAHDPnQ==
-  dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
+    "@fluentui/react-aria" "^9.3.2"
+    "@fluentui/react-avatar" "^9.2.7"
+    "@fluentui/react-checkbox" "^9.0.13"
+    "@fluentui/react-context-selector" "^9.1.2"
     "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-input" "^9.2.3"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-radio" "^9.0.12"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-spinner@^9.0.8":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-spinner/-/react-spinner-9.0.8.tgz#0112100efea13b0c0ec2a6e7114b616e60fb27f0"
-  integrity sha512-P6pQqp9VwWqJgbrJm21cDOdl9C0myYL5QboazREwYQOX8SEphwPk0nPMw5nnGhikRCyCPpu4H+qZg4EGZbhlog==
+"@fluentui/react-tabs@^9.1.1":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tabs/-/react-tabs-9.1.1.tgz#411101f2539580dc483c209b7a560bfec545efd9"
+  integrity sha512-MVfDvyiuk4RD9iXK6vsbD9bYu7KRLnxvjTrvzWYad4f7o+ViXEOl4x4RV23lzNs+LI1TDAtkwF8xiwExHQxjzQ==
   dependencies:
-    "@fluentui/react-label" "^9.0.8"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-switch@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-switch/-/react-switch-9.0.9.tgz#44510d630911082442a23ca04e881229bea786c0"
-  integrity sha512-wNpuWPqdytIo3ooEmLpaidEvdZw8fRGqy8yGhJmkxUNQLNK6JOtIuOuiJboijE14B7b+fscVPhob0g3OFnAMJA==
+"@fluentui/react-tabster@^9.3.1":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.3.1.tgz#ab732a62cf98cd8fcca0545b27f5834467c1dfe4"
+  integrity sha512-YHA9HBT32EIeLrfB9j5R0FUm3rz5aMxlj9IFlRtmN6mifohGkpVxB+qxNPZS4pqJrockrRD1cz8jL0a/bH3Ekw==
   dependencies:
-    "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-label" "^9.0.8"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-table@9.0.0-alpha.8":
-  version "9.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-table/-/react-table-9.0.0-alpha.8.tgz#cbd6c88206a97595e89476d89c3a9cda12ea0c70"
-  integrity sha512-Q4g2rymjDe052qieDtAGaV9GJqNIe5jFjzMj+Z0GORH/k+LP0UcN+NOrHP7qrKrfoMPB5mO9hUULNHf0IOYP6Q==
-  dependencies:
-    "@fluentui/react-aria" "^9.2.3"
-    "@fluentui/react-avatar" "^9.2.4"
-    "@fluentui/react-checkbox" "^9.0.10"
-    "@fluentui/react-icons" "^2.0.175"
-    "@fluentui/react-radio" "^9.0.9"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-tabs@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tabs/-/react-tabs-9.0.9.tgz#8b18cce48659eb96266b402ec3960d5cab3d4c0d"
-  integrity sha512-2eg/Spafs4OT7FLN2Qihw3giLcOlxxXkdJRMMZcPodhl3nCMmAJhnzanIMMoCUgAYtLqNGi3hmB1INj8CxEtTw==
-  dependencies:
-    "@fluentui/react-context-selector" "^9.0.5"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-tabster@^9.2.0":
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tabster/-/react-tabster-9.2.0.tgz#ae71a38b2961d5326649a360101dfaae44a1e2d4"
-  integrity sha512-9buxQUTAJ4Dts2S9Q7hLe+4yuO4OU/StrvQc0xv/it73D0hyVXna8C/FEVLYGYYaEeAlt9qehezw5KXhF6DXQA==
-  dependencies:
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     keyborg "^1.2.1"
     tabster "^3.0.4"
     tslib "^2.1.0"
 
-"@fluentui/react-text@^9.1.4":
-  version "9.1.4"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.1.4.tgz#5a4dd01a253b412fd881c7045c56b32caa0a929b"
-  integrity sha512-xc8IinzIzIg8ZwfSQnxSOs70dsfZIRO+MNxOMlyZ9ZTNAhOqDhytJaFiZJexwd3IxzIbc12pZnnWI6BSx257GQ==
+"@fluentui/react-text@^9.1.7":
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-text/-/react-text-9.1.7.tgz#609c4f8e4fdae91a88ade767d3fb7608aa5ec0a1"
+  integrity sha512-oyATvHX57/nSq6e+jlvyCNE2h2pOCOB+wRGvmOeDL+TxTxnoH1bL2cSkm0XlmOpluYuLUC20ck6j11WalzJCoQ==
   dependencies:
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-textarea@^9.1.3":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-textarea/-/react-textarea-9.1.3.tgz#fb374a8621f3bd2a9083bf0e01280d2e9edbeeb2"
-  integrity sha512-2wsr43rcQ+jL7LhJMDd4lek/SAy7cRHcu1rTwkP8UDHbe/N5U8SAdezjIelfcn/yhBDBULibW6CJSQNM7Qc1jg==
+"@fluentui/react-textarea@^9.1.6":
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-textarea/-/react-textarea-9.1.6.tgz#eb221cdcf6e292f83a2167b5c58d7fc3ccba23d2"
+  integrity sha512-+pmPbSZH3LoNPnc7O5pEvADhIqyXt6I1Bxvm2jw4qmJIzu+owNjkV622sHEsAqxVEPj0ML6STLOSwSjyHsFzNQ==
   dependencies:
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
+    "@fluentui/react-field" "9.0.0-alpha.9"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
     tslib "^2.1.0"
 
-"@fluentui/react-theme@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-theme/-/react-theme-9.1.1.tgz#daea387aab2ab811fbc34e248bff012ee79c8831"
-  integrity sha512-hUSjJkS8VGm2venEzLC0JRF/pxRxWBsLOcwX5E2xb07ZkE7+gPd5EJe7wpbxG796DBw/L2TvXhwDCTGMpLC5Mw==
-  dependencies:
-    tslib "^2.1.0"
-
-"@fluentui/react-toolbar@9.0.0-beta.11":
-  version "9.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-toolbar/-/react-toolbar-9.0.0-beta.11.tgz#7c2c53875a79691ac1aeed267c06d1a3dc08b1f8"
-  integrity sha512-SbxLew3TrOmZYuzugh/nvVKZ+fJX+UEsUi34jS1yMdG7cuXGR7Iv57lAysuunfyjwMBQzOSit+SAx5+x1JVGUw==
-  dependencies:
-    "@fluentui/react-button" "^9.1.6"
-    "@fluentui/react-context-selector" "^9.0.5"
-    "@fluentui/react-divider" "^9.1.2"
-    "@fluentui/react-radio" "^9.0.9"
-    "@fluentui/react-tabster" "^9.2.0"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-tooltip@^9.0.9":
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.0.9.tgz#1d274a76b6f96ab8806c9e2a85d83f3ea8a38023"
-  integrity sha512-5TJsCfKHQdqr67xzE9fh4iZoOt0WeiTJS1qsLNI192P5tVIyk95l7zLBg4I5wGuBkdtDXOrc4wq5AOkodKQCZQ==
-  dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
-    "@fluentui/react-portal" "^9.0.8"
-    "@fluentui/react-positioning" "^9.2.2"
-    "@fluentui/react-shared-contexts" "^9.0.2"
-    "@fluentui/react-theme" "^9.1.1"
-    "@fluentui/react-utilities" "^9.1.2"
-    "@griffel/react" "^1.4.1"
-    tslib "^2.1.0"
-
-"@fluentui/react-utilities@^9.1.2":
+"@fluentui/react-theme@^9.1.2":
   version "9.1.2"
-  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.1.2.tgz#893d26f069fd53063140f5bddfc5bcb16aa0c2d4"
-  integrity sha512-A55K4DzXI3gtBbCLNu975V/aoALnfyvcVkg4MDnrmK4zoHm/ksJXFbMZtNggBMRf4DVjTkdgrLnmQe593n00Dw==
+  resolved "https://registry.yarnpkg.com/@fluentui/react-theme/-/react-theme-9.1.2.tgz#f2794c3f4852f0a15a0caefab8de49b28229631d"
+  integrity sha512-+gxdVtm2zRXRe5Vzyr5ursWrHPs9p0hsq8OsWbYuHgW8MLf7cUscbKRt4eGYQ1l+vvFSOsk41uGkw3cQvh4DRA==
   dependencies:
-    "@fluentui/keyboard-keys" "^9.0.0"
     tslib "^2.1.0"
 
-"@griffel/core@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@griffel/core/-/core-1.8.0.tgz#2b798b64b59762eba504e2f2e5286fc93e5c1034"
-  integrity sha512-Z6gmkTc4031Uxf97caKuTwIlDR6MJ8VKVnbv7Z2koeITZjeRg2iMmo/4rXsS/sLTnbT9vqkDRiemBuseExLG/A==
+"@fluentui/react-toolbar@9.0.0-beta.14":
+  version "9.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-toolbar/-/react-toolbar-9.0.0-beta.14.tgz#fa84dfa26a7dd2ae50f0e42cf1e026d90e0dc004"
+  integrity sha512-VEWGWlRp9eKm6HCHqnqHtOqPa6uQ8wQP8JOkK0jb89Ods3c9FSsmb+sYFVm1B3iZfk5ls+4LIQUBj4Gg1elgHA==
   dependencies:
-    "@emotion/hash" "^0.8.0"
-    csstype "^3.0.10"
-    rtl-css-js "^1.16.0"
-    stylis "^4.0.13"
+    "@fluentui/react-button" "^9.1.9"
+    "@fluentui/react-context-selector" "^9.1.2"
+    "@fluentui/react-divider" "^9.1.5"
+    "@fluentui/react-radio" "^9.0.12"
+    "@fluentui/react-tabster" "^9.3.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-tooltip@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-tooltip/-/react-tooltip-9.1.2.tgz#8938c4a53ffafbfbba05990876eea44474b40f5d"
+  integrity sha512-f3kdXz9acfp3ZrzZo0DMqXHrSkqHg2n4vzR5r/654Qs3/9+oIQnzrFV7384+mk06OmmZbWh0pMF3wtFzKE7LoA==
+  dependencies:
+    "@fluentui/keyboard-keys" "^9.0.1"
+    "@fluentui/react-portal" "^9.0.11"
+    "@fluentui/react-positioning" "^9.3.2"
+    "@fluentui/react-shared-contexts" "^9.1.1"
+    "@fluentui/react-theme" "^9.1.2"
+    "@fluentui/react-utilities" "^9.2.2"
+    "@griffel/react" "^1.4.2"
+    tslib "^2.1.0"
+
+"@fluentui/react-utilities@^9.2.2":
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-utilities/-/react-utilities-9.2.2.tgz#d630ff0560333d49eb7ee8eb6b65b1f0dc54b35d"
+  integrity sha512-IlbTedlc3TjLxJtgSWmqfC9qqzb9rY2OmJ/sDtqS/gU7tumrQ0y/Pidsb8tSyRd9XByNtgVpA1DIimNVPaIvyQ==
+  dependencies:
+    "@fluentui/keyboard-keys" "^9.0.1"
     tslib "^2.1.0"
 
 "@griffel/core@^1.8.1":
@@ -1845,12 +1850,23 @@
     stylis "^4.0.13"
     tslib "^2.1.0"
 
-"@griffel/react@^1.0.0", "@griffel/react@^1.4.1":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.4.2.tgz#d4d3a9b24334e11cae188d8fb5574aa946e46cc2"
-  integrity sha512-VM047UxJFiq/OX5YkRPVuGB9NdU/TxVX9nrBRncXuxzVRRmvf+1OmHlcXWaFuXVj0JOjiMBzm4jH34lqPRGS+Q==
+"@griffel/core@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@griffel/core/-/core-1.8.2.tgz#4c8b43d6a7b394dfe918affba79190759263799e"
+  integrity sha512-OaLsE/6wkJzhI/5MOluYPUJV/YOIGxZ1AQi/hbLRnCbttCo5ey2nz70jiTBNHoCJ3muDcaNBoqMx0FDabURftQ==
   dependencies:
-    "@griffel/core" "^1.8.1"
+    "@emotion/hash" "^0.8.0"
+    csstype "^3.0.10"
+    rtl-css-js "^1.16.0"
+    stylis "^4.0.13"
+    tslib "^2.1.0"
+
+"@griffel/react@^1.0.0", "@griffel/react@^1.4.2":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@griffel/react/-/react-1.4.3.tgz#8c367eb0abb8e4936c80559506951dbe57b164a6"
+  integrity sha512-4XicmiKV1sscegPaiXLlIr22+jT+awAHWDu2bl19hwKiZcNUaQJ4XQ83me3rb1E+qw4dk6Uk6nwXAXTLBl7Sbw==
+  dependencies:
+    "@griffel/core" "^1.8.2"
     tslib "^2.1.0"
 
 "@humanwhocodes/config-array@^0.10.4":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2770,10 +2770,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^18.0.0":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
-  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.0.9":
+  version "18.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.9.tgz#ffee5e4bfc2a2f8774b15496474f8e7fe8d0b504"
+  integrity sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6739,9 +6739,9 @@ loader-runner@^4.2.0:
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
 
 loader-utils@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
-  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2719,10 +2719,10 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
-"@types/node@*", "@types/node@^18.11.8":
-  version "18.11.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.8.tgz#16d222a58d4363a2a359656dd20b28414de5d265"
-  integrity sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==
+"@types/node@*", "@types/node@^18.11.9":
+  version "18.11.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,10 +2712,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@*", "@types/jest@^29.2.0":
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.2.0.tgz#fa98e08b46ab119f1a74a9552c48c589f5378a96"
-  integrity sha512-KO7bPV21d65PKwv3LLsD8Jn3E05pjNjRZvkm+YTacWhVmykAb07wW6IkZUmQAltwQafNcDUEUrMO2h3jeBSisg==
+"@types/jest@*", "@types/jest@^29.2.3":
+  version "29.2.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.2.3.tgz#f5fd88e43e5a9e4221ca361e23790d48fcf0a211"
+  integrity sha512-6XwoEbmatfyoCjWRX7z0fKMmgYKe9+/HrviJ5k0X/tjJWHGAezZOfYaxqQKuzG/TvQyr+ktjm4jgbk0s4/oF2w==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"


### PR DESCRIPTION
> ## 🚀 Patch Tuesday update
> This pull request is a part of our new initiative!
From now on we are starting to roll out updates on every first Tuesday of the month, which will include bugfixes, security and dependency updates to keep the project's security and stability up to date!

## Description
Updated dependency libraries and added new language!

## Changelog
### Dependencies bump
- Bump @types/node from 18.11.8 to 18.11.9 (#65) 
- Bump sass from 1.55.0 to 1.56.1 (#73) 
- Bump loader-utils from 2.0.2 to 2.0.4 (#74) 
- Bump @fluentui/react-components from 9.6.1 to 9.7.1 (#76) 
- Bump @types/react-dom from 18.0.6 to 18.0.9 (#78) 
- Bump @types/jest from 29.2.0 to 29.2.3 (#77) 
### Fixed security vulnerabilities
- CVE-2022-37601
- CVE-2022-37603
- CVE-2022-37599
### Other changes
- Added Brazilian Portuguese locale (by @finalherizo, has been merged in #70)

## PR Checklist (main branch)
- [ ] Update extension version in `package.json`
- [ ] [Post-merge] Create a release to publish the new version
- [ ] [Post-deploy] Update changelog for Firefox webstore
