### PR TITLE
Fixed tooltip trigger area #81

### DIFF
--- a/src/Components/SettingsSection.tsx
+++ b/src/Components/SettingsSection.tsx
@@ -64,12 +64,14 @@ export default class SettingsSection extends React.Component<IProps>
 						</div>
 						<Divider />
 						<div className="stack">
-							<div>
-								<Tooltip content={ loc("Right-click password field to quickly generate password") } relationship="description">
-									<Checkbox label={ <Text>{ loc("Add shortcut to context menu") } <QuestionCircleRegular /></Text> }
-										checked={ settings.AddContext } onChange={ (_, e) => Settings.Update({ AddContext: e.checked as boolean }) } />
-								</Tooltip>
-							</div>
+							<Checkbox
+								checked={ settings.AddContext }
+								onChange={ (_, e) => Settings.Update({ AddContext: e.checked as boolean }) }
+								label={
+									<Tooltip content={ loc("Right-click password field to quickly generate password") } relationship="description">
+										<Text>{ loc("Add shortcut to context menu") } <QuestionCircleRegular /></Text>
+									</Tooltip>
+								} />
 							<Checkbox label={ loc("Automatically copy to clipboard") }
 								checked={ settings.Autocopy } onChange={ (_, e) => Settings.Update({ Autocopy: e.checked as boolean }) } />
 						</div>


### PR DESCRIPTION
fixes: #81

## Issue reference

> ### Description
> Hint tooltip for "Add shortcut to context menu" option is misaligned and appears only when hovering over checkbox
> 
> ### Reproduction steps
> Steps to reproduce the behavior:
> 1. Click extension icon to open popup
> 2. Click on 'Settings'
> 3. Hover on question mark on "Add shortcut to context menu" option
> 4. Tooltip doesn't appear
> 5. Hover on the option's checkbox
> 6. Tooltip appears
> 
> ### Expected behavior
> Tooltip should be attached to the question mark icon and appear when hovering over either checkbox, label or the icon
> 
> ### Screenshots
> ![image](https://user-images.githubusercontent.com/28831743/205928566-e48365ae-59df-443a-8d9f-b2eec2ce6673.png)
> 
> ### Environment
> Please provide the following information:
>  - Operating System: Windows 11 Pro 22H2 (22621.900)
>  - Browser: Microsoft Edge 107.0.1418.62 (Stable)
>  - Affected versions: >= 2.0.0, <= 2.1.0
