### PR TITLE
Workflow update

### DIFF
--- a/.github/workflows/cd_pipeline.yaml
+++ b/.github/workflows/cd_pipeline.yaml
@@ -5,6 +5,10 @@ on:
     types: [ released ]
   workflow_dispatch:
     inputs:
+      bypass_audit:
+        description: Bypass npm audit
+        type: boolean
+        default: false
       targets:
         description: Targets
         required: true
@@ -45,7 +49,6 @@ jobs:
 
       - run: npm install
       - run: npm run zip -- -b ${{ matrix.target }}
-      - run: npm audit
 
       - name: Drop build artifacts (${{ matrix.target }})
         uses: actions/upload-artifact@main
@@ -60,6 +63,9 @@ jobs:
         with:
           extension-root: ./.output/firefox-mv3
           self-hosted: false
+
+      - run: npm audit
+        if: ${{ github.event_name == "release" || github.event.inputs.bypass_audit == 'false' }}
 
   publish-github:
     needs: build

--- a/.github/workflows/pr_pipeline.yaml
+++ b/.github/workflows/pr_pipeline.yaml
@@ -39,7 +39,6 @@ jobs:
 
       - run: npm install
       - run: npm run zip -- -b ${{ matrix.target }}
-      - run: npm audit
 
       - name: Drop artifacts (${{ matrix.target }})
         uses: actions/upload-artifact@main
@@ -54,3 +53,5 @@ jobs:
         with:
           extension-root: ./.output/firefox-mv3
           self-hosted: false
+
+      - run: npm audit


### PR DESCRIPTION
## Description
Updated `cd_pipeline.yaml` and `pr_pipeline.yaml` to run `npm audit` at the very end, so other tasks (like dropping artifacts and `web-ext lint`) could be completed regardless of the audit results

Resolves: #443